### PR TITLE
Fix `list index out of range` error due to reusing `i` variable in inner loop

### DIFF
--- a/ether_tester.py
+++ b/ether_tester.py
@@ -443,6 +443,7 @@ cluster = Cluster(
     [
         Geth(
             eth_host_volume_path="~/.ethereum/docker",
+            container_command=Geth.ropsten_defaults + " --shh",
             description="Geth with Whisper service",
             init_time=20),
         Geth(

--- a/ether_tester.py
+++ b/ether_tester.py
@@ -1,15 +1,16 @@
-import subprocess
-import pandas
-from io import StringIO
-import time
+import datetime
+import fcntl
+import os
 import random
 import string
-import os
-import fcntl
-import datetime
-import yaml
+import subprocess
 import threading
+import time
+from io import StringIO
 from string import Template
+
+import pandas
+import yaml
 
 
 class Container(object):
@@ -96,14 +97,14 @@ class Geth(Container):
     is_wait_sync = False
     is_synced = False
 
-    def __init__(self, eth_value, container_command=None, version='latest', description=None, init_time=1,
+    def __init__(self, eth_host_volume_path, container_command=None, version='latest', description=None, init_time=1,
                  is_wait_sync=False):
         port = Geth.port_default + Geth.port.increment()
         json_rpc_port = Geth.json_rpc_port_default + Geth.json_rpc_port.increment()
 
         docker_command = 'docker run -i --rm -p {json_rpc_port}:8545 -p {port}:30303 ' \
-                         '-v {eth_value}:/root/.ethereum'.format(
-            json_rpc_port=json_rpc_port, port=port, eth_value=eth_value)
+                         '-v {eth_host_volume_path}:/root/.ethereum'.format(
+            json_rpc_port=json_rpc_port, port=port, eth_host_volume_path=eth_host_volume_path)
 
         if container_command is None:
             container_command = Geth.ropsten_defaults
@@ -441,11 +442,11 @@ class StatisticsCollector(object):
 cluster = Cluster(
     [
         Geth(
-            eth_value="~/.ethereum/docker",
+            eth_host_volume_path="~/.ethereum/docker",
             description="Geth with Whisper service",
             init_time=20),
         Geth(
-            eth_value="~/.ethereum/docker2",
+            eth_host_volume_path="~/.ethereum/docker2",
             description="Geth without Whisper service",
             init_time=20)
     ],
@@ -468,7 +469,7 @@ geth1 = ContainerManager(name=geth_docker_name1)
 
 start new container:
 g1 = Geth(
-    eth_value="~/.ethereum/docker",
+    eth_host_volume_path="~/.ethereum/docker",
     description="Geth with Whisper service",
     init_time=20)
 

--- a/ether_tester.py
+++ b/ether_tester.py
@@ -410,7 +410,7 @@ class StatisticsCollector(object):
                 if test_scenario is not None:
                     # in test_scenario the results of prev steps can be used in placeholders like '$result0' -
                     # https://docs.python.org/3.1/library/string.html#template-strings
-                    for i, test_command in enumerate(test_scenario):
+                    for j, test_command in enumerate(test_scenario):
                         test_command = Template(test_command).safe_substitute(template_dict)
                         print("Template", template_dict, test_command)
 
@@ -420,7 +420,7 @@ class StatisticsCollector(object):
                         if self.debug:
                             print(
                                 "Container {}, iteration {}: {}".format(self.containers[i].container.description,
-                                                                        i, res))
+                                                                        j, res))
 
                 data = self.containers[i].get_net_stats()
 


### PR DESCRIPTION
Fixes the following issues:
- list index out of range
```
Template {'result1': '', 'result0': ''} personal.newAccount("passphrase")
Template {'result1': '', 'result0': '0xaaa4a1a29b1ab3356af0a412511e0d301bc3b6c8'} miner.setEtherbase("0xaaa4a1a29b1ab3356af0a412511e0d301bc3b6c8")
Traceback (most recent call last):
  File "ether_tester.py", line 457, in <module>
    cluster.collect_stats(5, ['personal.newAccount(\"passphrase\")', 'miner.setEtherbase(\"$result0\")'])
  File "ether_tester.py", line 287, in collect_stats
    self.stats = self.stats_collector.collect_stats(n, test_scenario)
  File "ether_tester.py", line 417, in collect_stats
    res = self.containers[i].run(test_command, debug=self.debug)
IndexError: list index out of range
```

- `miner.setEtherbase("true")`
```
Template {'result1': '', 'result0': ''} personal.newAccount("passphrase")
Template {'result1': '', 'result0': '0x95ff3f9b53a5e893c7f14d66f5a0664b1291cb10'} miner.setEtherbase("0x95ff3f9b53a5e893c7f14d66f5a0664b1291cb10")
Template {'result1': '', 'result0': 'true'} personal.newAccount("passphrase")
Template {'result1': '', 'result0': 'true'} miner.setEtherbase("true")
Template {'result1': '0xa1fe7fb5c90362bbd52a6351b440335788ddb141"\nError: invalid address\nat web3.js:3930:15\nat web3.js:5025:28\nat map (<native code>)\nat web3.js:5024:12\nat web3.js:5050:18\nat web3.js:5075:23\nat <anonymous>:1:1', 'result0': 'true'} personal.newAccount("passphrase")
```